### PR TITLE
Make sure the MIT license shows up

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"email": "thegroup@filamentgroup.com",
 		"url": "http://filamentgroup.com"
 	},
+  "license": "MIT",
 	"engines": {
 		"node": "0.10"
 	},

--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-	"name": "fg-dialog",
-	"description": "simple dialog",
-	"version": "0.1.6",
-	"homepage": "https://github.com/filamentgroup/dialog",
-	"author": {
-		"name": "Filament Group",
-		"email": "thegroup@filamentgroup.com",
-		"url": "http://filamentgroup.com"
-	},
+  "name": "fg-dialog",
+  "description": "simple dialog",
+  "version": "0.2.0",
+  "homepage": "https://github.com/filamentgroup/dialog",
+  "author": {
+    "name": "Filament Group",
+    "email": "thegroup@filamentgroup.com",
+    "url": "http://filamentgroup.com"
+  },
   "license": "MIT",
-	"engines": {
-		"node": "0.10"
-	},
-	"scripts": {
-		"test": "./node_modules/.bin/grunt test --verbose"
-	},
-	"devDependencies": {
-		"grunt": "^0.4.5",
-		"grunt-cli": "^0.1.13",
-		"grunt-contrib-concat": "^0.5.1",
-		"grunt-contrib-jshint": "^0.11.2",
-		"grunt-contrib-qunit": "^0.7.0",
-		"grunt-contrib-uglify": "^0.9.1"
-	}
+  "engines": {
+    "node": "0.10"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/grunt test --verbose"
+  },
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-concat": "^0.5.1",
+    "grunt-contrib-jshint": "^0.11.2",
+    "grunt-contrib-qunit": "^0.7.0",
+    "grunt-contrib-uglify": "^0.9.1"
+  }
 }


### PR DESCRIPTION
It was missing from the package.json

Also, bumped the minor version, since adding a license change should be a noticeable change (major is preferred, but this is still < 1.x)