### PR TITLE
Negate native outline on dialog container, fixes #15

### DIFF
--- a/src/dialog.css
+++ b/src/dialog.css
@@ -5,9 +5,6 @@
  * Copyright (c) 2013 Filament Group, Inc.
  * Licensed under the MIT, GPL licenses.
  */
-.dialog {
-	outline: none;
-}
 .dialog-content,
 .dialog-background {
 	position: absolute;
@@ -41,6 +38,9 @@
 	.dialog-content {
 		width: 30em;
 	}
+}
+.dialog-open:focus {
+	outline: none;
 }
 .dialog-open,
 .dialog-background-open {

--- a/src/dialog.css
+++ b/src/dialog.css
@@ -5,6 +5,9 @@
  * Copyright (c) 2013 Filament Group, Inc.
  * Licensed under the MIT, GPL licenses.
  */
+.dialog {
+	outline: none;
+}
 .dialog-content,
 .dialog-background {
 	position: absolute;


### PR DESCRIPTION
We shift focus to the dialog and this causes an ugly focus color that makes it hard to see the custom shadow or other design elements.