### PR TITLE
handle hash in close, tests

### DIFF
--- a/src/dialog-init.js
+++ b/src/dialog-init.js
@@ -18,13 +18,13 @@
 				})
 				.bind( "click", function( e ){
 					if( $(e.target).closest(Dialog.selectors.close).length ){
-						w.history.back();
 						e.preventDefault();
+						dialog.close();
 					}
 				});
 
 			dialog.$background.bind( "click", function() {
-				w.history.back();
+				dialog.close();
 			});
 
 			// close on hashchange if open (supports back button closure)

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -102,6 +102,16 @@ window.jQuery = window.jQuery || window.shoestring;
 			return;
 		}
 
+		// if someone is calling close directly and the hash for this dialog is in
+		// the url then we need to go back, this will trigger the hashchange binding
+		// in init
+		// NOTE the bindings seem better in the constructor e.g.
+		// "#foo".indexOf("foo") === 1
+		if(window.location.hash.replace(/^#/, "") === this.hash){
+			window.history.back();
+			return;
+		}
+
 		this.$el.removeClass( cl.open );
 
 		this.$background.removeClass( cl.bkgdOpen );

--- a/test/dialog.js
+++ b/test/dialog.js
@@ -147,7 +147,7 @@
 		$(window).one("hashchange", function(){
 			equal(location.hash, "#dialog-dialog");
 
-			$(window).one("hashchange", function(){
+			$instance.one("dialog-closed", function(){
 				// the hash should not have changed ...
 				equal(location.hash, "#foo");
 

--- a/test/dialog.js
+++ b/test/dialog.js
@@ -1,4 +1,8 @@
 (function( $, window ) {
+	if(location.hash !== ""){
+		throw "Hash must be empty for tests to work properly";
+	}
+
 	var $doc, $instance, commonSetup, commonTeardown;
 
 	commonSetup = function() {
@@ -14,10 +18,18 @@
 	commonTeardown = function() {
 		$instance.unbind( "dialog-closed" );
 		$instance.unbind( "dialog-opened" );
-		$instance.trigger( "dialog-close" );
 
 		$instance.data( "instance" ).destroy();
 	};
+
+	// we have to give the browser the time to trigger a hashchange
+	// so there's no mixup
+	function closeInstance(){
+		$instance.trigger( "dialog-close" );
+		setTimeout(function(){
+			start()
+		}, 400);
+	}
 
 	module( "opening", {
 		setup: commonSetup,
@@ -27,7 +39,7 @@
 	var openTest = function( open ) {
 		$instance.one( "dialog-opened", function(){
 			ok( $instance.is(".dialog-open") );
-			start();
+			closeInstance();
 		});
 
 		ok( !$instance.is(".dialog-open") );
@@ -52,7 +64,7 @@
 	asyncTest( "with trigger sets the hash to #dialog", function() {
 		$instance.one( "dialog-opened", function(){
 			equal( location.hash, "#dialog-dialog" );
-			start();
+			closeInstance();
 		});
 
 		ok( !$instance.is(".dialog-open") );
@@ -91,6 +103,7 @@
 	};
 
 	asyncTest( "using trigger makes the dialog invisible", function() {
+		window.foo = true;
 		closeTest(function() {
 			$instance.trigger( "dialog-close" );
 		});
@@ -114,4 +127,40 @@
 			$( document ).trigger( keyupEvent );
 		});
 	});
+
+	asyncTest( "closing an open dialog clears the hash", function() {
+		$(window).one("hashchange", function(){
+			equal(location.hash, "#dialog-dialog");
+
+			$(window).one("hashchange", function(){
+				equal(location.hash, "");
+				start();
+			});
+
+			$instance.trigger("dialog-close");
+		});
+
+		$instance.trigger("dialog-open");
+	});
+
+	asyncTest( "closing an open dialog doesn't clear other hash", function() {
+		$(window).one("hashchange", function(){
+			equal(location.hash, "#dialog-dialog");
+
+			$(window).one("hashchange", function(){
+				// the hash should not have changed ...
+				equal(location.hash, "#foo");
+
+				// ... but the dialog should be closed
+				ok( !$instance.is(".dialog-open") );
+				start();
+			});
+
+			location.hash = "foo"
+			$instance.trigger("dialog-close");
+		});
+
+		$instance.trigger("dialog-open");
+	});
+
 })( window.jQuery || window.shoestring, this );


### PR DESCRIPTION
People are reasonably expecting `close` to just work wrt the hash but currently it doesn't. This fixes that by clearing the history where possible when `close` is called.