### PR TITLE
fix back button failure

### DIFF
--- a/src/dialog-init.js
+++ b/src/dialog-init.js
@@ -13,23 +13,24 @@
 			}
 
 			var dialog = new Dialog( this );
+			var onOpen, onClose, onClick, onBackgroundClick;
 
 			$el.addClass( Dialog.classes.content )
 
-				.bind( Dialog.events.open, function(){
+				.bind( Dialog.events.open, onOpen = function(){
 					dialog.open();
 				})
-				.bind( Dialog.events.close, function(){
+				.bind( Dialog.events.close, onClose = function(){
 					dialog.close();
 				})
-				.bind( "click", function( e ){
+				.bind( "click", onClick = function( e ){
 					if( $(e.target).closest(Dialog.selectors.close).length ){
 						e.preventDefault();
 						dialog.close();
 					}
 				});
 
-			dialog.$background.bind( "click", function() {
+			dialog.$background.bind( "click", onBackgroundClick = function() {
 				dialog.close();
 			});
 
@@ -51,10 +52,10 @@
 				}
 			});
 
-			onHashchange();
+			var onDocClick, onKeyup, onResize;
 
 			// open on matching a[href=#id] click
-			$( doc ).bind( "click", function( e ){
+			$( doc ).bind( "click", onDocClick = function( e ){
 				var $matchingDialog, $a;
 
 				$a = $( e.target ).closest( "a" );
@@ -72,7 +73,7 @@
 							$( "[id='" + id + "'],	[id='" + encodeURIComponent(id) + "']" );
 					} catch ( error ) {
 						// TODO should check the type of exception, it's not clear how well
-						//      the error name "SynatxError" is supported
+						//			the error name "SynatxError" is supported
 						return;
 					}
 
@@ -84,7 +85,7 @@
 			});
 
 			// close on escape key
-			$( doc ).bind( "keyup", function( e ){
+			$( doc ).bind( "keyup", onKeyup = function( e ){
 				if( e.which === 27 ){
 					dialog.close();
 				}
@@ -92,14 +93,31 @@
 
 			dialog._checkInteractivity();
 			var resizepoll;
-			$( window ).bind( "resize", function(){
+			$( window ).bind( "resize", onResize = function(){
 				if( resizepoll ){
 					clearTimeout( resizepoll );
 				}
 				resizepoll = setTimeout( function(){
 					dialog._checkInteractivity.call( dialog );
 				}, 150 );
-			} );
+			});
+
+			$el.bind("destroy", function(){
+				$(w).unbind("hashchange", onHashchange);
+
+				$el
+					.unbind( Dialog.events.open, onOpen )
+					.unbind( Dialog.events.close, onClose )
+					.unbind( "click", onClick );
+
+				dialog.$background.unbind( "click", onBackgroundClick);
+
+				$( doc ).unbind( "click", onDocClick );
+				$( doc ).unbind( "keyup", onKeyup );
+				$( window ).unbind( "resize", onResize );
+			});
+
+			onHashchange();
 
 			window.focusRegistry.register(dialog);
 		});

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -93,6 +93,8 @@ window.jQuery = window.jQuery || window.shoestring;
 		// unregister the focus stealing
 		window.focusRegistry.unregister(this);
 
+		this.$el.trigger("destroy");
+
 		// clear init for this dom element
 		this.$el.data()[pluginName] = undefined;
 
@@ -222,6 +224,7 @@ window.jQuery = window.jQuery || window.shoestring;
 			self._ariaHideUnrelatedElems();
 		});
 
+
 		this.$el.trigger( ev.opened );
 	};
 
@@ -252,28 +255,29 @@ window.jQuery = window.jQuery || window.shoestring;
 		// back if we can, or by adding a history state that doesn't have it at the
 		// end
 		if( window.location.hash.split( "#" ).pop() === this.hash ){
-			// let's check if the first segment in the hash is the same as the first
-			// segment in the initial hash if not, it's safe to use back() to close
-			// this out and clean the hash up
-			var firstHashSegment = window.location.hash.split( "#" )[ 1 ];
-			var firstInitialHashSegment = this.initialLocationHash.split( "#" )[ 1 ];
-			if( firstHashSegment && firstInitialHashSegment && firstInitialHashSegment !== firstHashSegment ){
-				window.history.back();
-			}
+			// check if we're back at the original hash, if we are then we can't
+			// go back again otherwise we'll move away from the page
+			var hashKeys = window.location.hash.split( "#" );
+			var initialHashKeys = this.initialLocationHash.split( "#" );
+
+			// if we are not at the original hash then use history
 			// otherwise, if it's the same starting hash as it was at init time, we
 			// can't trigger back to close the dialog, as it might take us elsewhere.
 			// so we have to go forward and create a new hash that does not have this
 			// dialog's hash at the end
-			else {
+			if( hashKeys.join("") !== initialHashKeys.join("") ){
+				window.history.back();
+			} else {
 				var escapedRegexpHash = this
-            .hash
-            .replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+						.hash
+						.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
 
 				window.location.hash = window
-          .location
-          .hash
-          .replace( new RegExp( "#" + escapedRegexpHash + "$" ), "" );
+					.location
+					.hash
+					.replace( new RegExp( "#" + escapedRegexpHash + "$" ), "" );
 			}
+
 			return;
 		}
 


### PR DESCRIPTION
Compare the initial hash with the current hash to ensure
that the browser doesn't move back past the hash from when
the dialog was instantiated.

Notably the current solution isn't particularly graceful in
cases where the dialog is intantiated late in the life of the page
(possibly after hashes have been added). We could record the initial
hash at load time for comparison.